### PR TITLE
Fix type of properties and constraints

### DIFF
--- a/afclCore/src/main/java/at/uibk/dps/afcl/SubFC.java
+++ b/afclCore/src/main/java/at/uibk/dps/afcl/SubFC.java
@@ -54,14 +54,14 @@ public class SubFC {
      * {@link PropertyConstraint} (information about the behaviour of functions)
      */
     @JsonProperty("properties")
-    private List<Object> propertiesSubFC = null;
+    private List<PropertyConstraint> propertiesSubFC = null;
 
     /**
      * {@link PropertyConstraint} (which must be fulfilled by underlying workflow
      * runtime environment)
      */
     @JsonProperty("constraints")
-    private List<Object> constraintsSubFC = null;
+    private List<PropertyConstraint> constraintsSubFC = null;
 
     /**
      * Constructor for sub function choreographies
@@ -130,22 +130,22 @@ public class SubFC {
     }
 
     @JsonProperty("properties")
-    public List<Object> getProperties() {
+    public List<PropertyConstraint> getProperties() {
         return propertiesSubFC;
     }
 
     @JsonProperty("properties")
-    public void setProperties(List<Object> propertiesSubFC) {
+    public void setProperties(List<PropertyConstraint> propertiesSubFC) {
         this.propertiesSubFC = propertiesSubFC;
     }
 
     @JsonProperty("constraints")
-    public List<Object> getConstraints() {
+    public List<PropertyConstraint> getConstraints() {
         return constraintsSubFC;
     }
 
     @JsonProperty("constraints")
-    public void setConstraints(List<Object> constraintsSubFC) {
+    public void setConstraints(List<PropertyConstraint> constraintsSubFC) {
         this.constraintsSubFC = constraintsSubFC;
     }
 

--- a/afclCore/src/main/java/at/uibk/dps/afcl/functions/objects/DataOuts.java
+++ b/afclCore/src/main/java/at/uibk/dps/afcl/functions/objects/DataOuts.java
@@ -61,14 +61,14 @@ public class DataOuts {
      * behaviour of functions)
      */
     @JsonProperty("properties")
-    private List<Object> propertiesDataOuts = null;
+    private List<PropertyConstraint> propertiesDataOuts = null;
 
     /**
      * {@link PropertyConstraint} (which must be fulfilled
      * by underlying workflow runtime environment)
      */
     @JsonProperty("constraints")
-    private List<Object> constraintsDataOuts = null;
+    private List<PropertyConstraint> constraintsDataOuts = null;
 
     public DataOuts() {
     }
@@ -141,22 +141,22 @@ public class DataOuts {
     }
 
     @JsonProperty("properties")
-    public List<Object> getProperties() {
+    public List<PropertyConstraint> getProperties() {
         return propertiesDataOuts;
     }
 
     @JsonProperty("properties")
-    public void setProperties(List<Object> properties) {
+    public void setProperties(List<PropertyConstraint> properties) {
         this.propertiesDataOuts = properties;
     }
 
     @JsonProperty("constraints")
-    public List<Object> getConstraints() {
+    public List<PropertyConstraint> getConstraints() {
         return constraintsDataOuts;
     }
 
     @JsonProperty("constraints")
-    public void setConstraints(List<Object> constraints) {
+    public void setConstraints(List<PropertyConstraint> constraints) {
         this.constraintsDataOuts = constraints;
     }
 

--- a/afclCore/src/main/java/at/uibk/dps/afcl/functions/objects/DataOutsAtomic.java
+++ b/afclCore/src/main/java/at/uibk/dps/afcl/functions/objects/DataOutsAtomic.java
@@ -55,14 +55,14 @@ public class DataOutsAtomic {
      * behaviour of functions)
      */
     @JsonProperty("properties")
-    private List<Object> propertiesDataOutsAtomic = null;
+    private List<PropertyConstraint> propertiesDataOutsAtomic = null;
 
     /**
      * {@link PropertyConstraint} (which must be fulfilled
      * by underlying workflow runtime environment)
      */
     @JsonProperty("constraints")
-    private List<Object> constraintsDataOutsAtomic = null;
+    private List<PropertyConstraint> constraintsDataOutsAtomic = null;
 
     public DataOutsAtomic() {
     }
@@ -123,22 +123,22 @@ public class DataOutsAtomic {
     }
 
     @JsonProperty("properties")
-    public List<Object> getProperties() {
+    public List<PropertyConstraint> getProperties() {
         return propertiesDataOutsAtomic;
     }
 
     @JsonProperty("properties")
-    public void setProperties(List<Object> properties) {
+    public void setProperties(List<PropertyConstraint> properties) {
         this.propertiesDataOutsAtomic = properties;
     }
 
     @JsonProperty("constraints")
-    public List<Object> getConstraints() {
+    public List<PropertyConstraint> getConstraints() {
         return constraintsDataOutsAtomic;
     }
 
     @JsonProperty("constraints")
-    public void setConstraints(List<Object> constraints) {
+    public void setConstraints(List<PropertyConstraint> constraints) {
         this.constraintsDataOutsAtomic = constraints;
     }
 


### PR DESCRIPTION
This PR changes the type of properties and constraints of DataOuts, DataOutsAtomic and SubFCs so that they get parsed and serialized  as expected.